### PR TITLE
Support Angular 2 router

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -22,7 +22,14 @@ import (
 //
 func DeepLink(next http.Handler, appURL string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if ext := filepath.Ext(r.URL.Path); ext == "" {
+		path := r.URL.Path
+
+		// Handle Angular 2 optional route parameters by removing them.
+		if i := strings.Index(path, ";"); i > -1 {
+			path = path[:i]
+		}
+
+		if ext := filepath.Ext(path); ext == "" {
 			r.URL.Path = appURL
 		}
 		next.ServeHTTP(w, r)


### PR DESCRIPTION
Handle deep linking for Angular 2 router. The new router has optional parameters that are separated by a semicolon (;) instead of question mark (?).  Handle this by removing everything after the first semicolon.  Don't think this will affect other valid routes.
